### PR TITLE
create badge component

### DIFF
--- a/packages/mds-components/src/components/badge/Badge.stories.ts
+++ b/packages/mds-components/src/components/badge/Badge.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Badge } from '@mds/components';
+
+export const Primary: StoryObj<Meta<typeof Badge>> = {};
+export const Secondary: StoryObj<Meta<typeof Badge>> = {};
+
+export default {
+  title: 'Components/Badge',
+  component: Badge,
+  args: {
+    badgeProps: {
+      type: 'primary',
+      anchorOrigin: { vertical: 'top', horizontal: 'left' },
+      content: 1,
+      invisible: true,
+      className: '',
+      shape: 'circle',
+    },
+    children: 'hi',
+  },
+} satisfies Meta<typeof Badge>;

--- a/packages/mds-components/src/components/badge/Badge.style.ts
+++ b/packages/mds-components/src/components/badge/Badge.style.ts
@@ -1,0 +1,66 @@
+import { css } from '@emotion/react';
+import { ComponentStyle } from '../../styles';
+import { BadgeProps } from './Badge';
+
+type BadgeType = NonNullable<BadgeProps['badgeProps']['type']>;
+
+const positionStyle: ComponentStyle<'default'> = {
+  default: css`
+    position: relative;
+    .badge__content {
+      position: absolute;
+      padding: 0 6px;
+      &.badge__top_left {
+        top: 0;
+        left: 0;
+        transform: translate(-50%, -50%);
+      }
+      &.badge__top_right {
+        top: 0;
+        right: 0;
+        transform: translate(50%, -50%);
+      }
+      &.badge__bottom_left {
+        bottom: 0;
+        left: 0;
+        transform: translate(-50%, 50%);
+      }
+      &.badge__bottom_right {
+        bottom: 0;
+        right: 0;
+        transform: translate(50%, 50%);
+      }
+    }
+  `,
+};
+
+const styles: ComponentStyle<BadgeProps['badgeProps']['type']> = {
+  primary: (theme) => css`
+    color: ${theme.Color.sys.primary.color};
+    background-color: ${theme.Color.sys.primary.container};
+  `,
+  secondary: (theme) => css`
+    color: ${theme.Color.sys.secondary.color};
+    background-color: ${theme.Color.sys.secondary.container};
+  `,
+};
+
+const shapes: ComponentStyle<BadgeProps['badgeProps']['shape']> = {
+  rectangle: css``,
+  circle: css`
+    border-radius: 50%;
+  `,
+};
+
+export const position = [positionStyle.default];
+export const badge = {
+  primary: [styles.primary],
+  secondary: [styles.secondary],
+  rectangle: [shapes.rectangle],
+  circle: [shapes.circle],
+} as ComponentStyle<BadgeType>;
+
+export default {
+  badge,
+  position,
+};

--- a/packages/mds-components/src/components/badge/Badge.tsx
+++ b/packages/mds-components/src/components/badge/Badge.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { ReactNode, useMemo } from 'react';
+import { MDSC, createMDSComponent } from '../shared';
+import BadgeStyle from './Badge.style';
+export interface BadgeOrigin {
+  vertical: 'top' | 'bottom';
+  horizontal: 'left' | 'right';
+}
+
+export interface BadgeOwnProps {
+  type: 'primary' | 'secondary';
+  shape: 'rectangle' | 'circle';
+  anchorOrigin: BadgeOrigin;
+  content: React.ReactNode;
+  invisible: boolean;
+  className: string;
+}
+export interface BadgeProps {
+  badgeProps: BadgeOwnProps;
+  children: ReactNode;
+}
+
+const Badge: MDSC<'span', BadgeProps> = ({
+  badgeProps,
+  css,
+  children,
+  className = '',
+  ...props
+}) => {
+  const prefixCls = 'badge__';
+  const badgeContentClassName = useMemo(() => {
+    const classNames = ['content'];
+
+    badgeProps.className && classNames.push(badgeProps.className);
+    badgeProps.anchorOrigin &&
+      classNames.push(
+        `${badgeProps.anchorOrigin.vertical}_${badgeProps.anchorOrigin.horizontal}`
+      );
+    badgeProps.shape && classNames.push(badgeProps.shape);
+    return classNames.map((i: string) => `${prefixCls}${i}`).join(' ');
+  }, [badgeProps.className, badgeProps.anchorOrigin]);
+
+  const badgeVisible = useMemo(() => {
+    return badgeProps.content && badgeProps.invisible;
+  }, [badgeProps.content, badgeProps.invisible]);
+
+  const componentProps = {
+    className: badgeContentClassName,
+    css: [
+      BadgeStyle.badge[badgeProps.type],
+      BadgeStyle.badge[badgeProps.shape],
+      css,
+    ],
+    children: badgeProps.content,
+  };
+  return (
+    <span
+      className={`badge__container ${className || ''}`}
+      css={[BadgeStyle.position, css]}
+    >
+      {children}
+      {badgeVisible && createMDSComponent(componentProps, 'span')}
+    </span>
+  );
+};
+
+export default Badge;

--- a/packages/mds-components/src/components/badge/index.ts
+++ b/packages/mds-components/src/components/badge/index.ts
@@ -1,0 +1,2 @@
+export * from './Badge';
+export { default as Badge } from './Badge';


### PR DESCRIPTION
## 작업내용
Badge component를 제작했습니다.
참고코드 : https://codesandbox.io/s/dotbadge-demo-material-ui-forked-h8cghf?file=/demo.js

## 주의사항
BadgeStyle에서 type과 shape를 같이 쓰는게 맞을지 확인해주세욤
export const badge = {
  primary: [styles.primary],
  secondary: [styles.secondary],
  rectangle: [shapes.rectangle],
  circle: [shapes.circle],
}

